### PR TITLE
replace video link on detail page

### DIFF
--- a/mysite/familytree/templates/familytree/video_detail.html
+++ b/mysite/familytree/templates/familytree/video_detail.html
@@ -4,15 +4,17 @@
 
 <div style="float: left; width: 65%;">
     <div style="margin-bottom: 20px">
-        <iframe
+        <video controls src="{{ media_server }}video/upload/h_600,r_20/{{ video.name }}"></video>
+
+        <!-- @@FIXME: this iframe stopped working after upgrading heroku stack, I'd liked having the controls -->
+        <!-- <iframe
             src= {{video_url}}
             width="800"
             height="500"
             allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
             allowfullscreen
             frameborder="0"
-        ></iframe>
-
+        ></iframe> -->
     </div>
     <div>
         {{ video.year }}


### PR DESCRIPTION
I noticed video had broken on the video detail page after upgrading the Heroku stack. 

Thumbnails still great on the dashboard (they use a partial using an a href)
Detail screen was using an iframe, no longer loading. Console errors: 
Source Map loading errors
   Failed to load resource: the server responded with a status of 404() 
TypeError: undefined is not an object
ReferenceError: Can't find variable: cloudinary

Since [this change](https://github.com/dianekaplan/django-familytree/pull/13/commits/66555caeb5dce53d8d20e746ac1b7ba2c0d22947) in 4/21/2021, we've used this iframe with video_url (resolves to a value like:
https://player.cloudinary.com/embed/?cloud_name=hhuyx4tno&public_id=1986_hannukah_1.mp4&vpv=1.4.0), which comes from views.py: `video_url = "https://player.cloudinary.com/embed/?" + params`

For now updating to using the video tag that we use for the thumbnails (in chrome, sigh, I liked keeping the old way for safari because it does autoplay) 
