### PR TITLE
temp: update default time zone

### DIFF
--- a/mysite/mysite/settings.py
+++ b/mysite/mysite/settings.py
@@ -95,7 +95,8 @@ DJANGO_SITE_CREATION = datetime.strptime("2021-07-14", "%Y-%m-%d").date()
 NEWEST_GENERATION_FOR_GUEST = 13
 ADMIN_EMAIL_SEND_FROM = "diane@ourbigfamilytree.com"
 ADMIN_EMAIL_ADDRESS = "dianekaplan@gmail.com"
-DEFAULT_TIME_ZONE = "US/Eastern"
+# DEFAULT_TIME_ZONE = "US/Eastern"
+DEFAULT_TIME_ZONE = "America/New_York"
 
 
 if ENV_ROLE == "development":


### PR DESCRIPTION
New Internal Server error on the user metrics page! 
No error in local, staging shows: 
ZoneInfoNotFoundError at /familytree/user_metrics/
'No time zone found with key US/Eastern'
^ that's set in my settings.py: DEFAULT_TIME_ZONE = "US/Eastern", used when making a Profile
Try updating to: DEFAULT_TIME_ZONE = "America/New_York"