### PR TITLE
set default sender

### DIFF
--- a/mysite/mysite/settings.py
+++ b/mysite/mysite/settings.py
@@ -96,6 +96,7 @@ NEWEST_GENERATION_FOR_GUEST = 13
 ADMIN_EMAIL_SEND_FROM = "diane@ourbigfamilytree.com"
 ADMIN_EMAIL_ADDRESS = "dianekaplan@gmail.com"
 DEFAULT_TIME_ZONE = "US/Eastern"
+DEFAULT_FROM_EMAIL = 'dianekaplan@gmail.com'
 
 
 if ENV_ROLE == "development":


### PR DESCRIPTION
With current Django version, when you do the password reset flow the from address is: `webmaster@localhost [via] mg.ourbigfamilytree.com`, which is ending up in people's spam folders. Set DEFAULT_FROM_EMAIL in settings.py