### PR TITLE
Revert update

### DIFF
--- a/mysite/familytree/templates/registration/password_reset_done.html
+++ b/mysite/familytree/templates/registration/password_reset_done.html
@@ -7,7 +7,7 @@
   </p>
   <p>
     If you don't receive an email, please make sure you've entered the address you previously registered with,
-    and check your spam folder.
+    and <b>check your spam folder for email with subject "Family tree account password reset"</b>.
   </p>
 <p>
   If you hit any problems, please <a href="mailto:dianekaplan@gmail.com?subject=Family tree user request">let me know</a>!

--- a/mysite/mysite/settings.py
+++ b/mysite/mysite/settings.py
@@ -96,7 +96,6 @@ NEWEST_GENERATION_FOR_GUEST = 13
 ADMIN_EMAIL_SEND_FROM = "diane@ourbigfamilytree.com"
 ADMIN_EMAIL_ADDRESS = "dianekaplan@gmail.com"
 DEFAULT_TIME_ZONE = "US/Eastern"
-DEFAULT_FROM_EMAIL = 'dianekaplan@gmail.com'
 
 
 if ENV_ROLE == "development":


### PR DESCRIPTION
Setting the DEFAULT_FROM_EMAIL for mailgun to use made the email client (gmail at least) warn that it might be a spoofed email (arguably worse), so for now let's revert that change and just update the language to have the user check their spam folder. 