### PR TITLE
handle story updates in dashboard updates view

### DIFF
--- a/mysite/familytree/templates/familytree/dashboard.html
+++ b/mysite/familytree/templates/familytree/dashboard.html
@@ -88,7 +88,7 @@
     {% if not user_is_guest %}
     <div class="circled_section">
         <b>Latest updates:</b><br/>
-        {% for update, person, content_type, change_type, updated_person in recent_updates %}
+        {% for update, person, content_type, change_type, updated_person, updated_story in recent_updates %}
            {% include "familytree/update_partial.html"%}
         {% endfor %}
     </div>

--- a/mysite/familytree/templates/familytree/update_partial.html
+++ b/mysite/familytree/templates/familytree/update_partial.html
@@ -9,6 +9,10 @@
 
         {% if updated_person %}
                 {% include "familytree/face_name_link.html" with person=updated_person %}
+        {% elif updated_story %}
+                <a href="{% url 'story' updated_story.id %}">this story
+                <img src="{% static 'familytree/book.png' %}" height="30"/>
+                </a>
         {% elif content_type == 'family' %}
                 <a href="{% url 'family_detail' update.object_id %}">{{ update.object_repr }}</a>
         {% elif content_type == 'story' %}

--- a/mysite/familytree/views.py
+++ b/mysite/familytree/views.py
@@ -77,7 +77,7 @@ def index(request):  # dashboard page
     )
 
     # only include additions or updates, for family, person, story, notes
-    display_action_types = [1, 2]
+    display_action_types = [1, 2]  # added, updated
     display_update_types = [2, 4, 5, 9]
     recent_logentries = LogEntry.objects.filter(
         content_type_id__in=display_update_types, action_flag__in=display_action_types
@@ -89,15 +89,20 @@ def index(request):  # dashboard page
         update_author = update.user
         user_person = Profile.objects.get(user=update_author).person
         updated_person = None
+        updated_story = None
 
-        if update.content_type_id == 4:
+        if update.content_type_id == 4:  # Person update
             updated_person = Person.objects.get(id=update.object_id)
+        
+        if update.content_type_id == 5:  # Story update (including association with person/family)
+            updated_story = Story.objects.get(id=update.object_id)
 
         content_type = str(ContentType.objects.get(id=update.content_type_id)).replace(
             "familytree | ", ""
         )
         change_type = "added" if update.action_flag == 1 else "updated"
-        combination = [update, user_person, content_type, change_type, updated_person]
+        updated_story = Story.objects.get(id=update.object_id)
+        combination = [update, user_person, content_type, change_type, updated_person, updated_story ]
         recent_updates.append(combination)
 
     # get list of people with birthdays this month


### PR DESCRIPTION
After adding a story and associating with people/families, I saw it included in the 'Latest Updates' list on the dashboard without an object to show: 
Diane Kaplan updated 1 day ago
Diane Kaplan added 1 day ago

Update to pull in the link to the story when it's a story being added/updated