### PR TITLE
update to force POST request for logout (django 5)

### DIFF
--- a/mysite/familytree/templates/familytree/top_nav.html
+++ b/mysite/familytree/templates/familytree/top_nav.html
@@ -41,12 +41,19 @@
               <div class="dropdown-menu">
                 <a class="dropdown-item" href="{% url 'account' %}">My Updates</a>
                 <a class="dropdown-item" href="{% url 'password_reset' %}">Reset Password</a>
-                <a class="dropdown-item" href="{% url 'logout' %}">Log out</a>
+
+                <form id="logout-form" action="{% url 'logout' %}" method="post">
+                  <a class="dropdown-item" href="#" onclick="document.getElementById('logout-form').submit(); return false;">Log out</a>
+                  {% csrf_token %}
+              </form>
               </div>
             </li>
             {% else %}
               <li class="nav-item">
-                <a class="dropdown-item" href="{% url 'logout' %}">Log out</a>
+                <form id="logout-form" action="{% url 'logout' %}" method="post">
+                  <a class="dropdown-item" href="#" onclick="document.getElementById('logout-form').submit(); return false;">Log out</a>
+                  {% csrf_token %}
+              </form>
               </li>
             {% endif %}
 


### PR DESCRIPTION
BUG: logout having an issue in prod: 405 method not allowed

This error occurs because Django's built-in LogoutView expects a POST request for security reasons, to prevent Cross-Site Request Forgery (CSRF) attacks. If you try to log out using a direct URL, which sends a GET request, Django will reject it and show the 405 Error.

Update the 'Log out' link variations to force a POST